### PR TITLE
Fixed formatting bug

### DIFF
--- a/lib/src/common/utils.dart
+++ b/lib/src/common/utils.dart
@@ -29,7 +29,7 @@ class Utils {
 
   static String formatAmount(num amountInBase) {
     if (_currencyFormatter == null) throw "Currency formatter not initalized.";
-    return _currencyFormatter.format((amountInBase / 100));
+    return _currencyFormatter.format(amountInBase);
   }
 
   static validateChargeAndKey(Charge charge) {


### PR DESCRIPTION
The balance previously displayed the balance / 100  e.g 500 Naira was displayed as 5 Naira. I fixed that by removing the division by 100. 