### PR TITLE
Unresolved reference to VERSION_NAME & VERSION_CODE

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,8 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         versionCode 21
         versionName "3.0.10"
+        buildConfigField 'int', 'VERSION_CODE', "21"
+        buildConfigField 'String', 'VERSION_NAME', "\"3.0.10\""
     }
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
Android Studio 4.1 — or, more accurately, version 4.1.0 of the Android Gradle Plugin — has a breaking change: it no longer adds VERSION_CODE (and, sometimes, VERSION_NAME), to BuildConfig. as a result of the issue here : https://issuetracker.google.com/issues/158695880#comment15
What worked for me was to declare them manually, based on this issue comment:

  ```
defaultConfig {
    minSdkVersion 21
    targetSdkVersion 30
    versionCode 1
    versionName "1.0"
    buildConfigField 'int', 'VERSION_CODE', "1"
    buildConfigField 'String', 'VERSION_NAME', "\"1.0\""

    testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
    consumerProguardFiles "consumer-rules.pro"
  }
```
In my case, I just hard-coded the values, but you could arrange to pull them from some common location.