### PR TITLE
Update pubspec.yaml for fixing intl  version issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.5
-  intl: ^0.17.0
+  intl: ^0.19.0
   meta: ^1.8.0
   async: ^2.9.0
 


### PR DESCRIPTION
Because every version of flutter_paystack from git depends on intl ^0.17.0 and app depends on intl ^0.19.0, flutter_paystack from git is forbidden. So, because app depends on flutter_paystack from git, version solving failed.